### PR TITLE
docs: add research and design rationale

### DIFF
--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,20 @@
+# Research & Design References
+
+This directory contains research materials and design rationale gathered during the planning phase of RedGuard Suite. These documents capture industry best practices, tool evaluations, and architectural decisions that informed the project design.
+
+## Documents
+
+| File | Topic | Source |
+|------|-------|--------|
+| [initial_design.md](initial_design.md) | Original repo architecture, tool integrations, and transition to local deployment | Planning phase |
+| [modern_red_team_practices.md](modern_red_team_practices.md) | What modern red teams and security firms actually do — toolchains, methods, and design principles | Industry research |
+| [executive_validation.md](executive_validation.md) | Security model validation, toolchain assessment, legal/compliance, maturity roadmap | Architecture review |
+| [garak_integration_plan.md](garak_integration_plan.md) | Garak (LLM red teaming) integration design, probe categories, and automation patterns | AI security research |
+
+## How These Inform the Project
+
+- **Architecture**: The modular pipeline design and config-driven approach came from studying how enterprise red teams chain tools
+- **Safety**: The multi-layer safety architecture (dry_run, allowed_networks, stop_on_prod) was informed by operational risk analysis
+- **ATT&CK Mapping**: The technique coverage plan draws from real engagement workflows documented here
+- **AI/LLM Testing**: The Garak integration approach follows the patterns validated in the executive review
+- **Governance**: Data classification, encryption requirements, and legal considerations shaped the public/internal repo split

--- a/docs/research/executive_validation.md
+++ b/docs/research/executive_validation.md
@@ -1,0 +1,104 @@
+# Executive Validation & Architecture Review
+
+> Assessment of the RedGuard Suite approach against enterprise security practices.
+
+## Executive Summary
+
+The public/generic framework with private fork pattern is aligned with modern security engineering practices, mirroring patterns used by OWASP tool ecosystems, MITRE ATT&CK-based testing frameworks, Red Canary Atomic Red Team methodology, and enterprise red-team automation pipelines.
+
+When implemented correctly, this structure:
+- Protects sensitive data
+- Enables open innovation and community collaboration
+- Supports reproducible testing
+- Allows continuous improvement without risk leakage
+
+Tool orchestration alone does not equal red teaming maturity. True value comes from data enrichment, scenario modelling, business impact mapping, and continuous learning loops.
+
+## 1. Security & Governance Model Validation
+
+### Public/Private Fork Pattern — Strengths
+- **Public repo**: Orchestration logic, tooling wrappers, documentation, templates
+- **Private fork**: Targets and topology, credentials and seed data, attack path intelligence, detection gaps and findings
+
+### Critical Controls
+
+**Secret & Data Protection**: SOPS with age/KMS, git-crypt, hardware-backed key storage, encrypted vault (HashiCorp Vault). Avoid plaintext configs entirely.
+
+**Data Classification Tags**: Add classification headers to sensitive files (CLASSIFICATION, OWNER, RETENTION) for ISO 27001 and audit readiness.
+
+**Supply Chain Security**: SBOM generation (CycloneDX), dependency pinning and hash verification, container image scanning (Trivy, Grype), signed releases (Sigstore Cosign).
+
+## 2. Toolchain Assessment (2026)
+
+### Recon & OSINT
+- **ReconFTW**: Still one of the most complete recon automation suites; may overwhelm with noise — requires filtering layer
+- **OWASP Amass**: Excellent for attack surface mapping
+- **2026 trend**: Attack surface management moving toward continuous discovery pipelines, certificate transparency monitoring, exposed secrets monitoring
+
+### Vulnerability & Exploitation
+- **Nuclei**: Dominant templated scanning engine, integrates well into CI/CD
+- **Metasploit**: Useful but noisy and detectable; better for controlled labs
+- **Modern focus**: Misconfigurations, identity and privilege paths, cloud posture drift, API attack surfaces
+
+### C2 & Emulation
+- **Sliver**: Widely respected modern C2, strong cross-platform support
+- **Mythic**: Extremely powerful but complex
+- **Enterprise reality**: Focus on stealth persistence, identity abuse, living-off-the-land over classic implants
+
+### Atomic Testing & Social Engineering
+- **Atomic Red Team**: Excellent for detection validation and blue team collaboration
+- **Gophish**: Industry standard; requires strong legal and HR approval workflows
+
+## 3. AI-Enhanced Red Teaming
+
+### AI Roles in Offensive Simulation
+- **Output analysis & summarization**: Identify attack chains, highlight privilege escalation paths, translate findings into executive language
+- **Pattern discovery**: Recurring weaknesses, systemic policy failures, identity governance gaps
+- **Scenario generation**: Insider threat behaviors, vendor compromise scenarios, lateral movement strategies
+
+### Emerging AI Risk Domain
+- Prompt injection, data exfiltration via LLM context, model poisoning, agent tool abuse
+- Framework should include AI risk modules to be future-proof
+
+## 4. Legal & Compliance (UK/EU Enterprise Context)
+
+### UK Legal Considerations
+- **Computer Misuse Act 1990**: Testing must be explicitly documented, approved in writing, scope-controlled
+- **UK GDPR**: Phishing simulations may process personal data — requires DPIA, proportionality review, anonymization
+
+### EU Parent Company Considerations
+- NIS2 Directive obligations, supply chain risk testing, cyber resilience reporting
+- Red team outputs may become regulatory artifacts
+
+## 5. Operational Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Tool orchestration without insight | Focus on attack path analysis, identity abuse, business process compromise |
+| Alert fatigue and detection tuning overload | Use Atomic tests to validate detection engineering |
+| Over-automation causing outages | Safety controls, rate limits, kill switches, change windows |
+
+## 6. Architectural Improvements Recommended
+
+### Attack Path Engine
+BloodHound-style graph analysis for identity attack path mapping, privilege escalation simulation, lateral movement modelling. Delivers far more value than scan reports.
+
+### Business Impact Mapping Layer
+Map technical compromise to: production downtime, IP exposure, safety risks, regulatory penalties. Makes exec reports actionable.
+
+### Detection Gap Feedback Loop
+Automatically: trigger attack simulation → check SIEM detection → log detection gaps → open remediation tickets. Aligns red and blue teams.
+
+## 7. Maturity Roadmap
+
+| Phase | Focus |
+|-------|-------|
+| 1. Foundation | Generic orchestration repo, local fork, recon and vuln modules |
+| 2. Identity & Attack Paths | AD/Entra attack modelling, privilege escalation mapping |
+| 3. Detection Engineering | Atomic Red Team automation, SIEM validation loop |
+| 4. AI Augmentation | Automated reporting, pattern discovery, scenario generation |
+| 5. Continuous Adversary Simulation | Continuous attack surface monitoring, drift detection, cloud/identity posture testing |
+
+## Final Assessment
+
+This approach is modern, scalable, security-conscious, aligned with enterprise red team evolution, and future-proof when AI modules are included. Success depends on governance and legal controls, identity and attack path focus, business impact analysis, blue team integration, and controlled automation.

--- a/docs/research/garak_integration_plan.md
+++ b/docs/research/garak_integration_plan.md
@@ -1,0 +1,106 @@
+# Garak LLM Red Teaming Integration Plan
+
+> Design and implementation plan for integrating NVIDIA Garak into RedGuard Suite.
+
+## Overview
+
+Garak (Generative AI Red-teaming & Assessment Kit) acts as an "nmap/Metasploit for LLMs" — systematically probing models for vulnerabilities like prompt injection, jailbreaks, hallucination, data leakage, toxicity generation, and misinformation.
+
+### Why Integrate Garak
+
+- **Complements existing stack**: Dedicated AI/LLM-specific phase alongside traditional red team modules
+- **Continuous and automated**: Run in CI/CD-like loops on test models, feed results to DefectDojo
+- **Ethical and authorized**: Fully open-source (Apache 2.0), CLI-driven, designed for authorized red teaming
+- **Actively maintained**: NVIDIA + community, with new probes for emerging threats like multi-turn crescendo attacks
+
+## 1. Public Repo Integration (Generic)
+
+### Module Design
+
+Add as `src/redguard/modules/llm_garak.py` with standard module interface:
+
+```python
+def run(config: dict) -> dict:
+    """Run Garak probes against configured LLM endpoints."""
+    dry_run = config.get("safety", {}).get("dry_run", True)
+    garak_config = config.get("llm_garak", {})
+
+    if dry_run:
+        return {"status": "dry_run", "detail": "Would run Garak probes"}
+
+    # Build Garak CLI command from config
+    cmd = ["garak", "--model_type", garak_config["model_type"]]
+    if "model_name" in garak_config:
+        cmd.extend(["--model_name", garak_config["model_name"]])
+    if "uri" in garak_config:
+        cmd.extend(["--uri", garak_config["uri"]])
+
+    cmd.extend(["--probes", ",".join(garak_config.get("probes", ["default"]))])
+    cmd.extend(["--detectors", ",".join(garak_config.get("detectors", ["default"]))])
+    # ... execute and parse results ...
+```
+
+### Config Schema
+
+```json
+{
+  "llm_garak": {
+    "model_type": "rest",
+    "uri": "http://localhost:11434/v1/chat/completions",
+    "probes": ["prompt_injection", "jailbreak", "data_leakage", "hallucination"],
+    "detectors": ["default"]
+  }
+}
+```
+
+### Probe Categories
+
+| Category | What It Tests | ATLAS Mapping |
+|----------|---------------|---------------|
+| Prompt Injection | Override system instructions | AML.T0051 |
+| Jailbreak | Bypass safety guardrails | AML.T0054 |
+| Data Leakage | Exfiltrate training/context data | AML.T0025 |
+| Hallucination | Generate false/harmful information | N/A |
+| Toxicity | Produce harmful or offensive content | N/A |
+| Encoding-based | Unicode/encoding attacks to bypass filters | AML.T0051 |
+
+## 2. Internal Overlay (Company-Specific)
+
+### Custom Probes
+- Domain-specific data leakage testing (proprietary information, supplier data)
+- Business-context toxicity testing (harmful advice in company domain)
+- RAG poisoning — test if retrieval-augmented generation can be manipulated
+
+### Automation
+- Schedule weekly scans via cron/Ansible on staging LLM instances
+- Parse Garak JSON reports → feed to local LLM (Ollama) for executive summary
+- Integrate with risk matrix: "LLM Prompt Injection Success → Data Exfil" (Severity: Critical)
+
+### Orchestration Chain
+1. **Recon** → Discover LLM-exposed endpoints (Nuclei templates for /v1/chat, OpenAI-compatible APIs)
+2. **If found** → Auto-trigger Garak probes
+3. **Post-scan** → If vulnerabilities detected → simulate exploit in test environment
+4. **Report** → Aggregate probe-by-probe results with repro prompts, impact, and mitigations
+
+## 3. Best Practices
+
+- **Run in isolation**: Use test/staging LLM instances only — never prod without explicit RoE
+- **Ethical use**: Document all probes as authorized testing
+- **Updates**: Periodically pull from upstream NVIDIA/garak for new probes
+- **Complement**: Pair with PyRIT for more dynamic, goal-oriented multi-turn attacks
+
+## GitHub Repos by Phase (Reference)
+
+| Phase | Repositories |
+|-------|-------------|
+| Recon | six2dez/reconftw, OWASP/Amass, projectdiscovery/httpx |
+| Scan | projectdiscovery/nuclei, nmap/nmap, zaproxy/zaproxy |
+| C2 | BishopFox/sliver, its-a-feature/Mythic |
+| BAS | redcanaryco/atomic-red-team, facebookincubator/TTPForge |
+| LLM | NVIDIA/garak, Azure/PyRIT |
+
+## Lab Planning Notes
+
+- Use Kali Linux for operator parity and training, but keep automation portable
+- Docker-based toolchain avoids hard dependencies on Kali packages
+- Enforce safe lab standards: VM snapshots, network isolation, change windows

--- a/docs/research/initial_design.md
+++ b/docs/research/initial_design.md
@@ -1,0 +1,61 @@
+# Initial Design: Generic Red Team Suite
+
+> Sanitized version of original planning notes. Company-specific references removed.
+
+## Approach
+
+This project prioritizes data security by keeping the public GitHub repository fully generic (no company-specific data, configs, or references), while enabling a seamless fork or clone to a private/local Git setup where authorized real-world details can be integrated.
+
+## Step 1: Generic GitHub Repository
+
+Create a public repo hosting a modular, extensible framework that chains open-source tools for red teaming phases. Focus on documentation, scripts, and Dockerfiles — no placeholders for sensitive data. License under MIT or Apache 2.0 for easy forking.
+
+### Repo Structure (Original Design)
+
+- `/docs/` — Setup guides, phase overviews, ethical guidelines, MITRE ATT&CK mappings
+- `/modules/` — Subdirs for each phase (recon, vuln_scan, c2, phishing, ai_enhance, atomic_tests)
+- `/orchestrator/` — Core Python scripts to chain modules via CLI
+- `/configs/` — Generic YAML/JSON templates with safe placeholders
+- `/reports/` — Output templates and exec summary generation
+- `/tests/` — Unit tests and sample datasets
+- `/ci-cd/` — GitHub Actions for linting, building, smoke tests
+
+### Integrated Tools (2026)
+
+1. **Recon & OSINT**: ReconFTW, Amass, SpiderFoot, Sherlock, Woodpecker (API/K8s)
+2. **Vuln Scanning & Exploitation**: Nmap, Nuclei, Metasploit, ZAP
+3. **C2 & Emulation**: Sliver (primary), Mythic, Havoc, AdaptixC2
+4. **Atomic/Scenario Testing**: Atomic Red Team, TTPForge
+5. **Phishing & Social Engineering**: Gophish, Social-Engineer Toolkit, AI-generated lures via Ollama
+6. **AI Enhancements**: reconftw_ai, PentestGPT, PyRIT, Woodpecker, CAI, OpenRT
+7. **Orchestration**: Python (Click/argparse), Ansible, Docker, Rigging for agent harnesses
+
+## Step 2: Transition to Local Git with Real Data
+
+### Customization Process
+
+1. Clone and branch for internal use
+2. Add real data securely (encrypted via git-crypt or SOPS)
+3. Enhance for company-specific risks (OT/ICS, cloud paths, identity abuse)
+4. Build risk assessment engine with LLM-powered analysis
+5. Implement security controls (encryption, RBAC, audit logs, lab isolation)
+
+### AI Learning Loop
+
+- Use local LLM (Ollama on air-gapped hardware) to analyze past runs
+- Fine-tune on anonymized logs for evolving TTP suggestions
+- Pull public zero-days via NVD API and simulate
+
+## Operational Principles
+
+- Toolchains and automation matter more than any single tool; pair with human analysis
+- Identity and attack paths are primary risk; prioritize privilege path mapping
+- Continuous validation beats annual point-in-time tests
+- Detection feedback loops improve both red and blue team outcomes
+
+## Governance and Safety
+
+- Encrypt sensitive configs (SOPS/age or vault) — no plaintext data in public repos
+- Data classification headers and retention tags for audit readiness
+- Supply chain controls: SBOM generation, pinned dependencies, signed releases, image scanning
+- Safety gates: dry-run defaults, rate limits, kill switches, change windows

--- a/docs/research/modern_red_team_practices.md
+++ b/docs/research/modern_red_team_practices.md
@@ -1,0 +1,108 @@
+# What Modern Red Teams & Security Firms Actually Do
+
+> Research synthesis of professional red team practices, tool patterns, and operational disciplines.
+
+## Key Reality
+
+Professional red teams rarely rely on a single tool. Instead they use toolchains, automation pipelines, custom scripting, threat intelligence, business-context modelling, and detection engineering feedback loops.
+
+## 1. Inspiration from Leading Red-Team Platforms
+
+### Cobalt Strike
+- Reliable C2, malleable traffic profiles, lateral movement tooling
+- **Lesson**: Stealth and evasion matter more than exploitation; post-compromise actions create real risk; modular payload and comms design
+
+### Bishop Fox Sliver (Open-source C2)
+- Modern implant design, cross-platform, encrypted comms, operator UX
+- **Lesson**: Operational reliability and operator visibility are critical
+
+### SpecterOps & BloodHound Ecosystem
+- Identity attack path mapping — most breaches involve identity abuse, not exploits
+- Reveals: privilege escalation chains, shadow admin accounts, unintended trust relationships
+- **Critical insight**: Identity is the new perimeter
+
+### Red Canary Atomic Red Team
+- Validate detection coverage continuously, test behaviors not tools, map to MITRE ATT&CK
+- **Lesson**: Detection validation is as important as attack simulation
+
+### AttackIQ / SafeBreach (Breach & Attack Simulation)
+- Continuous adversary simulation, automated scenario testing, risk scoring
+- **Lesson**: Continuous testing beats annual pentests
+
+## 2. Tools Used by Penetration Testers
+
+### Recon & Attack Surface Mapping
+- OWASP Amass and OSINT tools map infrastructure, discover forgotten assets, enumerate trust relationships
+- **Insight**: The biggest risks are often unknown assets
+
+### Nuclei (ProjectDiscovery)
+- Template-driven scanning, rapid vulnerability coverage, automation friendly
+- **Takeaway**: Templated automation scales expertise
+
+### Burp Suite
+- Workflow efficiency matters; manual + automated testing combination; human insight still critical
+
+## 3. Methods Used by Elite Red Teams
+
+### Threat Emulation (not random testing)
+- Simulate real adversaries: ransomware groups, insider threats, supply chain attackers, nation-state tradecraft
+- Inspired by MITRE ATT&CK
+
+### Identity & Privilege Escalation Focus
+- Credential theft, token abuse, Kerberos delegation flaws, OAuth abuse, MFA bypass
+- These techniques work because identity is the primary attack surface
+
+### Living-Off-The-Land Techniques (LOLBins)
+- PowerShell, WMI, built-in admin tools, scheduled tasks, cloud CLI tools
+- Harder to detect than traditional malware
+
+### Cloud & SaaS Attack Paths
+- Azure/Entra ID privilege paths, AWS IAM misconfigurations, API exposure, OAuth consent abuse, SSO trust relationships
+
+### Persistence & Stealth
+- Hidden admin roles, long-lived tokens, conditional access bypass, mailbox forwarding rules, backdoor service principals
+
+## 4. How AI is Changing Red Teaming
+
+- **AI-assisted recon analysis**: LLMs summarize findings and highlight risks
+- **AI-generated phishing pretexts**: Realistic lures from OSINT
+- **Attack chain analysis**: AI identifies highest-risk paths
+- **Defensive evasion research**: AI generates technique variants
+
+## 5. How Security Consultancies Deliver Value
+
+What clients pay for:
+- **Attack path narratives** — not vulnerability lists
+- **Business risk translation** — "This misconfiguration enables ransomware deployment in under 2 hours"
+- **Detection gap identification** — what wasn't seen by SOC tools
+- **Process failures** — joiner/mover/leaver failures, vendor onboarding weaknesses, weak MFA policy
+
+## 6. Common Engagement Workflow
+
+1. **Recon & Intelligence**: Asset discovery, employee OSINT, supply chain mapping
+2. **Initial Access**: Phishing, password spraying, exposed service exploitation
+3. **Privilege Escalation**: Identity abuse, misconfiguration exploitation
+4. **Lateral Movement**: Trust path exploitation, token reuse
+5. **Persistence & Impact**: Data exfiltration simulation, ransomware deployment simulation
+6. **Detection & Response Review**: SOC visibility gaps, response time, containment effectiveness
+
+## 7. What Tools Don't Teach (But Pros Know)
+
+- Tools are not breaches — misconfigurations + identity flaws cause most compromises
+- CVSS scores don't equal risk — context matters
+- Attack paths matter more than individual vulnerabilities
+- Human processes are often the weakest link
+
+## 8. Design Principles for RedGuard Suite
+
+These principles directly inform the project architecture:
+
+- Identity-first security testing
+- Attack path modelling
+- Continuous validation
+- Detection engineering feedback loop
+- AI-assisted analysis and prioritization
+- Business risk storytelling
+- Automation + human insight hybrid
+- Cloud and SaaS focus
+- Stealth and persistence testing


### PR DESCRIPTION
## Summary
- Sanitized and organized 4 planning-phase research documents into `docs/research/`
- Covers: initial architecture design, modern red team industry practices, executive architecture validation, and Garak LLM integration plan
- All company-specific references removed for public repo safety
- Includes README index linking documents to project decisions they informed

## Test plan
- [ ] Verify no company-specific data in any document
- [ ] Verify all markdown renders correctly on GitHub
- [ ] Cross-reference design principles match project architecture

🤖 Generated with [Claude Code](https://claude.com/claude-code)