### PR TITLE
docs: complete research library with remaining sources

### DIFF
--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -10,6 +10,9 @@ This directory contains research materials and design rationale gathered during 
 | [modern_red_team_practices.md](modern_red_team_practices.md) | What modern red teams and security firms actually do — toolchains, methods, and design principles | Industry research |
 | [executive_validation.md](executive_validation.md) | Security model validation, toolchain assessment, legal/compliance, maturity roadmap | Architecture review |
 | [garak_integration_plan.md](garak_integration_plan.md) | Garak (LLM red teaming) integration design, probe categories, and automation patterns | AI security research |
+| [tooling_reference.md](tooling_reference.md) | GitHub repos by capability, Kali influence, standards/frameworks, operational maturity notes | Tool evaluation |
+| [landscape_2026.md](landscape_2026.md) | 2026 red teaming trends, phase-specific optimization guidance, actionable best practices | Landscape research |
+| [learning_roadmap.md](learning_roadmap.md) | Red team learning path, OSINT training resources, exploit intelligence feeds, skill map | Skills development |
 
 ## How These Inform the Project
 
@@ -18,3 +21,5 @@ This directory contains research materials and design rationale gathered during 
 - **ATT&CK Mapping**: The technique coverage plan draws from real engagement workflows documented here
 - **AI/LLM Testing**: The Garak integration approach follows the patterns validated in the executive review
 - **Governance**: Data classification, encryption requirements, and legal considerations shaped the public/internal repo split
+- **Tooling**: The tooling reference and 2026 landscape research directly informed tool selection and integration priorities
+- **Skills**: The learning roadmap captures the professional development path that complements the technical framework

--- a/docs/research/landscape_2026.md
+++ b/docs/research/landscape_2026.md
@@ -1,0 +1,54 @@
+# 2026 Red Teaming Landscape & Phase Guidance
+
+> Research synthesis of 2026 trends, phase-specific optimization guidance, and actionable best practices for red team frameworks.
+
+## 2026 Landscape Summary
+
+- **Core Trends**: Red teaming shifts to "threat-informed" practices per MITRE's 2026 R&D Roadmap, integrating CTI maturity models with red/blue team simulations for quantifiable defense gaps. Open-source frameworks emphasize modularity (Docker-native chaining) and AI for adaptive TTPs, with increasing tool support for EDR evasion.
+- **AI Enhancements**: Tools like Garak and DeepTeam dominate LLM red teaming, focusing on multi-turn attacks and guardrail calibration. Ethical AI red teaming best practices include context-enriched prompts and automated reporting to reduce false positives.
+- **Tool Integrations**: Sliver and Mythic excel in cross-platform C2 (including OT pivots), integrating seamlessly with Nuclei/ReconFTW. Garak pairs with PyRIT for dynamic LLM attacks, boosting coverage of adversarial ML techniques (MITRE ATLAS).
+- **Challenges**: Reports highlight "digital parasite" threats (silent persistence in supply chains) and the need for hardware-optimized AI testing (GPU-accelerated Garak runs). Open-source adoption continues to grow, but ethical guidelines are critical for enterprise trust.
+
+## Phase-Specific Guidance
+
+### 1. Recon & OSINT
+- ReconFTW + Amass covers the majority of subdomain discovery; integrate LLM-driven prioritization to flag high-value targets (e.g., supplier portals).
+- Automate ethical scraping with rate limits; enrich with credential leak databases. Output: JSON targets for downstream chaining.
+
+### 2. Vuln Scanning & Exploitation
+- Nuclei templates updated for current CVEs; pair with Metasploit for supply chain exploit scenarios.
+- Use BloodHound CE for Entra ID paths; simulate attack vectors via Atomic Red Team mappings (e.g., T1190: Exploit Public-Facing App).
+
+### 3. C2 & Adversary Emulation
+- Sliver's dynamic compilation evades most EDRs; Mythic's agents support OT protocols (e.g., Modbus pivots).
+- Run multi-C2 (Sliver + Havoc) for evasion testing; map to ATT&CK techniques like T1078 (Valid Accounts).
+
+### 4. Phishing & Social Engineering
+- Gophish + AI-generated lures boost realism; focus on multi-turn phishing per current best practices.
+- Use OSINT seeds for personalized simulations; track metrics like click rates in DefectDojo.
+
+### 5. LLM Red Teaming (Garak Integration)
+- Garak probes 40+ vulnerability types (prompt injection, data leakage, etc.); enhance with DeepTeam for OWASP-aligned attacks.
+- Target ATLAS extensions (adversarial inputs); calibrate detectors for false positives. Chain: Recon → Discover LLM endpoints → Garak probes → Simulate exfiltration.
+
+### 6. Orchestration, Reporting & Continuous Loop
+- Python/Ansible wrappers enable CI/CD-like automation; local LLM fine-tuning evolves TTPs from run logs.
+- Generate risk matrices via LLM (e.g., Impact: High for OT halt); integrate maturity scoring models.
+
+## Hints & Tips: Actionable Best Practices
+
+| Category | Guidance | Why It Matters |
+|----------|----------|----------------|
+| **Modularity** | Submodule upstream tools. Use YAML/JSON for configs; validate with Pydantic. Add plugin system (entry points for custom probes). | Enables quick updates with ATT&CK version changes; reduces maintenance overhead. |
+| **Evasion & Realism** | Test against EDR shadows; use Sliver's mTLS for LOTL. Simulate persistent threats with Atomic tests (T1547). Randomize payloads via agent features. | Reflects real attacker success patterns; avoids "blue team wins by default." |
+| **AI/LLM Optimization** | Enrich Garak prompts with multi-turn context. Fine-tune local LLMs on anonymized logs for zero-day suggestions. Integrate PyRIT for goal-oriented attacks alongside Garak. | Boosts LLM vulnerability detection; covers emerging ATLAS threats. |
+| **Ethics & Compliance** | Embed RoE checks (abort on prod IPs via geofencing). Log all actions with timestamps; audit via ELK stack. Use ethics modules for LLM probes. | Aligns with GDPR and enterprise policy; builds trust for scaling. |
+| **Performance & Automation** | Containerize with Docker Compose; use Kubernetes for scaled pilots. Schedule via Ansible Tower; integrate Jira/Slack for alerts. | Enables persistent runs; cuts manual effort significantly. |
+| **Testing & Iteration** | Unit test wrappers with pytest; fuzz inputs for robustness. Run maturity assessments quarterly. Open-source generic repo for community PRs. | Ensures reliability; evolves with emerging threats. |
+
+## Key References
+
+- MITRE ATT&CK & INFORM maturity model: [attack.mitre.org](https://attack.mitre.org)
+- AI Red Teaming best practices: [promptfoo.dev](https://www.promptfoo.dev/docs/red-team/), [hiddenlayer.com](https://hiddenlayer.com/innovation-hub/ai-red-teaming-best-practices)
+- Tool integrations: [plextrac.com](https://plextrac.com), [itsecurityguru.org](https://www.itsecurityguru.org)
+- Broader guides: [practical-devsecops.com](https://www.practical-devsecops.com/ai-red-teaming-beginners-guide), [cycognito.com](https://www.cycognito.com/learn/red-teaming)

--- a/docs/research/learning_roadmap.md
+++ b/docs/research/learning_roadmap.md
@@ -1,0 +1,119 @@
+# Red Team Learning Roadmap & Resources
+
+> Self-directed learning path from intermediate security testing to modern red team operations, with curated OSINT, exploit intelligence, and training resources.
+
+## 1. What Modern Red Teaming Actually Is
+
+Modern red teaming is less about "find as many vulns as possible" and more about **emulating real adversaries end-to-end**:
+
+- Uses MITRE ATT&CK to plan campaigns by tactics/techniques rather than just CVEs
+- Focuses on **adversary emulation**: picking a threat group or breach pattern and recreating its TTPs
+- Leverages **breach and attack simulation (BAS)** platforms to continuously test controls
+- Integrates with defenders (purple teaming) to improve detection engineering and incident response
+- Includes **cloud, SaaS, identity, supply-chain and social engineering** paths — reflecting how real breaches happen
+
+## 2. Core Skill Map
+
+1. **Offensive fundamentals (web, infra, AD)** — Web app vulns, auth flows, deserialization, SSRF, IDOR; AD abuse, Kerberos, delegation, pivoting, tunnelling
+2. **Cloud & SaaS** — Common misconfigs and abuse paths in AWS/Azure/GCP, M365/Entra, OAuth/OIDC
+3. **OSINT & social engineering** — People, infrastructure, supply-chain mapping; phishing, vishing, pretext development, OPSEC
+4. **Adversary emulation & tooling** — ATT&CK-driven planning, C2 frameworks, EDR evasion, BAS platforms
+5. **Automation & scripting** — Python/PowerShell/Bash for tooling, data parsing, engagement automation
+6. **Reporting & consultancy** — Executive narratives, clear attack paths, remediation-oriented recommendations
+
+## 3. Learning Phases
+
+### Phase 1 — Sharpen Offensive Fundamentals (6-12 months)
+
+**Hands-on practice:**
+- TryHackMe "Jr Penetration Tester" and "Pentest+" paths for structured fundamentals
+- TCM Security "Certified Practical Penetration Tester" as a practical starting point
+- OSCP / CRTP (AD-focused) as stretch goals for exam-style validation
+
+**Key skills to emphasise:**
+- Windows/AD attack chains (initial access → privesc → DC compromise → persistence)
+- Pivoting and C2 basics (redirectors, OPSEC, traffic blending)
+- Internal phishing / help-desk style social engineering
+
+### Phase 2 — Red Teaming & Adversary Emulation (6-12 months)
+
+**Framework & methodology:**
+- Study MITRE ATT&CK deeply; learn to design scenarios from it
+- Model known threat groups relevant to target sectors
+- Select technique chains to emulate; map findings back to ATT&CK
+
+**Tools and platforms:**
+- Open-source BAS: Caldera, Infection Monkey, Metta, Atomic Red Team
+- Commercial awareness: SCYTHE, SafeBreach, Picus, Pentera
+
+**Target capability:** Take a real-world breach pattern → decompose into ATT&CK techniques → recreate in lab → demonstrate impact.
+
+### Phase 3 — OSINT and Human-Centric Operations
+
+**OSINT frameworks and tools:**
+- OSINT Framework (lockfale) — classic index of free OSINT tools
+- doctorfree/osint — curated list (SpiderFoot, Maltego, Shodan, Recon-ng, IntelOwl)
+- OSIF — Metasploit-style CLI for OSINT tasks
+
+**Training resources:**
+- SANS SEC497: Practical Open-Source Intelligence
+- IMSL (UK) OSINT courses — Ofqual-approved Level 1 and 3
+- Seiber OSINT Practitioner (UK) — 5-day course on legalities and tradecraft
+- My OSINT Training (MOT) — practical, exercise-driven
+
+**Staying current on OSINT tradecraft:**
+- The OSINT Newsletter — tools, techniques, investigations
+- Monthly OSINT Roundup — curated tips and tool updates
+
+### Phase 4 — Business, Compliance, and Service Delivery
+
+**Legal & compliance:**
+- Understand and operate within Computer Misuse Act (UK) and related legislation
+- Draft standard engagement documents: RoE, scope of work, NDAs, data handling
+- Consider professional indemnity insurance and ISO-aligned processes
+
+**Service packaging examples:**
+- Web/app pentest packages (small/medium/large)
+- Internal & AD assessment / assumed-breach exercise
+- Red team engagement: threat-informed campaign mapped to ATT&CK
+- OSINT-driven attack surface review
+
+## 4. Vulnerability & Exploit Intelligence Feeds
+
+Build a **weekly feed routine** around:
+
+| Source | Focus |
+|--------|-------|
+| [Exploit-DB](https://www.exploit-db.com) | Public exploit PoCs; learning how exploits are built and chained |
+| [Zero Day Initiative (ZDI)](https://www.zerodayinitiative.com/advisories/) | Regular vulnerability advisories including active 0-days |
+| [Zero-day.cz](https://www.zero-day.cz/database/) | 0-day tracking database |
+| [Google Project Zero](https://projectzero.google/0day.html) | Analysis and stats on real-world exploited vulnerabilities |
+| [Rapid7 zero-day blog](https://www.rapid7.com/blog/tag/zero-day/) | Ongoing analysis and response guidance |
+| [Red Canary](https://redcanary.com/blog/) | Annual threat detection reports for TTP-level trends |
+
+## 5. Keeping Methods Modern
+
+Two key shifts:
+
+1. **AI-powered red teaming and continuous testing** — AI-driven platforms simulate attacks 24/7 across cloud and API surfaces
+2. **2025 breach lessons** — major incidents involved compromised third-party helpdesks, supply-chain/OAuth token theft, and internet-exposed industrial systems with default credentials
+
+When designing services and lab practice, deliberately target:
+- Third-party and help-desk processes
+- OAuth/OIDC and SSO misconfigurations in SaaS
+- Default/exposed management interfaces in cloud and OT/IoT
+
+## 6. Realistic Weekly Routine
+
+**Daily (30-60 minutes)**
+- 1 lab box (TryHackMe/HTB/own infra)
+- 10-15 minutes reading: one exploit write-up or red teaming article
+
+**Weekly**
+- 1-2 hours of structured course material
+- Design or extend one mini-attack chain in lab
+- Review new 0-day / exploit summaries from feeds
+
+**Monthly**
+- Write a short, client-style report for one lab engagement
+- Update personal playbooks: initial access techniques, common misconfigs, OSINT sources

--- a/docs/research/tooling_reference.md
+++ b/docs/research/tooling_reference.md
@@ -1,0 +1,62 @@
+# Tooling Reference & Operational Standards
+
+> Centralized reference of external tools, standards, and operational maturity guidance for RedGuard Suite.
+
+## GitHub Repos (By Capability)
+
+### Recon and Discovery
+- six2dez/reconftw
+- OWASP/Amass
+- projectdiscovery/httpx
+- projectdiscovery/nuclei
+- nmap/nmap
+
+### Web and App Testing
+- zaproxy/zaproxy
+- rapid7/metasploit-framework
+
+### Identity and Attack Paths
+- SpecterOps/BloodHound
+- mitre/caldera
+
+### C2 and Emulation
+- BishopFox/sliver
+- its-a-feature/Mythic
+
+### BAS and Detection Validation
+- redcanaryco/atomic-red-team
+- facebookincubator/TTPForge
+
+### Social Engineering (Authorized Only)
+- gophish/gophish
+- trustedsec/social-engineer-toolkit
+
+### LLM and AI Security
+- NVIDIA/garak
+- Azure/PyRIT
+- promptfoo/promptfoo
+
+## Kali Linux Influence
+
+- Kali is the reference operator environment for many teams and toolchains.
+- Keep automation portable and OS-agnostic; avoid hardcoding Kali paths.
+- Prefer containerized tools so Windows or macOS operators can run the same workflows.
+- Enforce lab hygiene: isolated networks, snapshots, and explicit scope controls.
+
+## Standards and Frameworks
+
+- MITRE ATT&CK and ATLAS for TTP mapping and scenario design.
+- OWASP guidance for web application testing.
+- NIST and ISO 27001 for governance alignment and audit readiness.
+
+## Operational Maturity Notes
+
+- Attack path narratives and time-to-impact metrics outperform CVE-only reporting.
+- Detection feedback loops are core to sustained value (simulate, validate, tune).
+- Identity abuse and cloud/SaaS paths are the dominant real-world risk areas.
+
+## Supply Chain and Safety Controls
+
+- Pin dependencies, generate SBOMs, and sign releases for public artifacts.
+- Encrypt internal configurations (SOPS or vault) and add classification headers.
+- Use dry-run defaults, rate limits, and kill switches to prevent outages.


### PR DESCRIPTION
## Summary
- Add 3 sanitized research documents to `docs/research/`:
  - **tooling_reference.md** — GitHub repos by capability, Kali influence, standards/frameworks, supply chain controls
  - **landscape_2026.md** — 2026 red teaming trends, phase-specific guidance, actionable best practices table
  - **learning_roadmap.md** — Red team skill map, 4-phase learning path, OSINT training resources, exploit intelligence feeds
- Update `docs/research/README.md` index with new documents and project linkages

## Context
These were sourced from previously unincorporated research files (Research-Appendix.md, Grok-further research.txt, Perplexity Research.md), sanitized to remove any company-specific references.

## Test plan
- [ ] Verify all markdown renders correctly
- [ ] Confirm no company-specific or sensitive data in new files
- [ ] Check all internal links in README.md resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)