### PR TITLE
feat(config): add per-company config overlays (#18)

### DIFF
--- a/configs/overlays/README.md
+++ b/configs/overlays/README.md
@@ -1,0 +1,51 @@
+# Config Overlays
+
+This directory holds **per-company configuration overlays** for RedGuard Suite.
+
+An overlay is a small YAML document that is layered on top of a base config to
+produce the effective configuration for a single engagement. The pattern keeps
+shared defaults in one place (`default.yaml`) while letting each engagement
+override only the values it needs (`<company>.yaml`).
+
+> **Public repo safety:** Every file in this directory is a *template*. It must
+> only ever contain safe placeholders — `example.com`, fictional company names
+> such as `acme-corp`, and `0.0.0.0`-style addresses. Real domains, IPs,
+> credentials, or company names belong in the private `internal/` overlay repo,
+> never here. See [`CLAUDE.md`](../../CLAUDE.md) and [`SECURITY.md`](../../SECURITY.md).
+
+## How overlays are layered
+
+Overlays are merged in order, last-writer-wins, with dictionaries merged
+recursively and scalars/lists replaced wholesale:
+
+```
+base config (configs/config.public.example.json)
+  └── default.yaml        # defaults shared by every company
+        └── <company>.yaml # engagement-specific overrides
+```
+
+The resulting document uses the same schema as the JSON configs consumed by the
+orchestrator (`targets`, `modules`, `risk_matrix`, `safety`, ...), so a merged
+overlay can be serialised to JSON and passed to `redguard --config`.
+
+## Files
+
+| File             | Purpose                                                        |
+| ---------------- | ------------------------------------------------------------- |
+| `default.yaml`   | Baseline overlay every engagement inherits. Safe by default.   |
+| `acme-corp.yaml` | Worked example of a per-company overlay (fictional company).    |
+
+## Creating a new overlay
+
+1. Copy `acme-corp.yaml` to `<your-company>.yaml`.
+2. Override only the keys that differ from `default.yaml`.
+3. Keep `safety.dry_run: true` unless an authorised, signed Rules of Engagement
+   (RoE) explicitly permits active testing for the scoped window.
+4. Validate that the file contains no real targets before committing to a public
+   repo — company-specific values go in the private `internal/` repo.
+
+## Merge precedence summary
+
+- **Dictionaries** are deep-merged.
+- **Lists and scalars** from the higher-precedence overlay replace the lower one.
+- Keys absent from an overlay fall through to the layer below.

--- a/configs/overlays/acme-corp.yaml
+++ b/configs/overlays/acme-corp.yaml
@@ -1,0 +1,39 @@
+# Per-company config overlay — EXAMPLE
+#
+# "Acme Corp" is a fictional company used to demonstrate the overlay pattern.
+# This file overrides only the keys that differ from default.yaml; everything
+# else (risk_matrix, unset safety controls, etc.) falls through to the default.
+#
+# SAFETY: Public template. All values are placeholders. A real engagement's
+# overlay lives in the private internal/ repo, never here.
+
+engagement:
+  company: "acme-corp"
+  environment: "staging"
+  authorized_window: "2026-07-01T09:00Z/2026-07-01T17:00Z"
+
+# Engagement-specific scope. Still placeholders in the public repo.
+targets:
+  - "app.staging.example.com"
+  - "api.staging.example.com"
+
+# Acme's engagement exercises the scanning and LLM modules in addition to the
+# defaults.
+modules:
+  recon: true
+  scan: true
+  llm_garak: true
+  report: true
+
+safety:
+  # Active testing authorised for the staging window above per signed RoE.
+  dry_run: false
+  stop_on_prod: true
+  exclusions:
+    - "payments.staging.example.com"
+    - "*.prod.example.com"
+
+rules_of_engagement:
+  approved_by: "REPLACE_IN_INTERNAL_REPO"
+  deconfliction_contact: "appsec@example.com"
+  emergency_stop_contact: "soc@example.com"

--- a/configs/overlays/default.yaml
+++ b/configs/overlays/default.yaml
@@ -1,0 +1,48 @@
+# Default config overlay
+#
+# Baseline values inherited by every engagement. Per-company overlays
+# (e.g. acme-corp.yaml) are layered on top of this file and override only the
+# keys they need.
+#
+# SAFETY: This is a public template. Use only safe placeholders here
+# (example.com, fictional names). Real values live in the private internal/ repo.
+
+# Engagement metadata. Overridden per company.
+engagement:
+  company: "default"
+  environment: "non-production"
+  # Authorised window for active testing. Empty means "not authorised yet".
+  authorized_window: ""
+
+# Targets in scope. Always placeholders in the public repo.
+targets:
+  - "example.com"
+
+# Which attack-phase modules run by default. Conservative defaults: passive
+# phases on, anything intrusive off until a company overlay opts in.
+modules:
+  recon: true
+  scan: false
+  llm_garak: false
+  report: true
+
+# Safety controls. dry_run MUST stay true unless a signed RoE authorises active
+# testing for the scoped window. stop_on_prod aborts if a production target is
+# detected.
+safety:
+  dry_run: true
+  stop_on_prod: true
+  # Out-of-scope hosts that must never be touched, even if discovered.
+  exclusions:
+    - "*.example.org"
+
+# Risk matrix dimensions used by the report engine.
+risk_matrix:
+  impact_levels: ["Low", "Medium", "High", "Critical"]
+  likelihood_levels: ["Rare", "Possible", "Likely", "Almost Certain"]
+
+# Rules of Engagement and deconfliction contacts. Placeholders only.
+rules_of_engagement:
+  approved_by: "REPLACE_IN_INTERNAL_REPO"
+  deconfliction_contact: "security-team@example.com"
+  emergency_stop_contact: "soc@example.com"


### PR DESCRIPTION
Add configs/overlays/ with a layered, per-engagement config template
pattern:

- default.yaml: safe baseline every engagement inherits (dry_run on,
  conservative module set, placeholder targets/contacts).
- acme-corp.yaml: worked example of a per-company overlay (fictional
  company, example.com placeholders only).
- README.md: documents the overlay/merge precedence and public-repo
  safety rules.

All values are safe placeholders; real company data stays in the
private internal/ overlay repo per CLAUDE.md safety rules.

Note: placed under configs/ (matching the existing configs/ dir) rather
than the config/ path in the issue, and used YAML per the issue request.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
