### PR TITLE
feat(config): encrypted config management (SOPS + Vault) (#21)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,10 @@ reports/*.html
 **/company_*
 **/purina_*
 *.vault
+
+# Decrypted SOPS secrets - only ciphertext (*.enc.yaml) may be committed
+config/secrets.yaml
+config/secrets.json
+config/*.dec.yaml
+config/*.dec.json
+.sops.yaml

--- a/.sops.yaml.example
+++ b/.sops.yaml.example
@@ -1,0 +1,20 @@
+# SOPS configuration — copy to `.sops.yaml` and replace the placeholder public
+# keys with each operator's real `age1...` PUBLIC key (age-keygen prints it).
+#
+# Only PUBLIC keys belong here. Never put an AGE-SECRET-KEY-... value in this file.
+# `.sops.yaml` is git-ignored by default; commit it only if your team policy
+# allows publishing the recipient list.
+#
+# See config/encrypted-config.md for the full workflow.
+
+creation_rules:
+  # Any secrets file under config/ is encrypted to the operators below.
+  - path_regex: config/secrets\.(enc\.)?ya?ml$
+    age: >-
+      age1exampleoperatoraaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaq,
+      age1exampleoperatorbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbq
+
+  - path_regex: config/secrets\.(enc\.)?json$
+    age: >-
+      age1exampleoperatoraaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaq,
+      age1exampleoperatorbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbq

--- a/config/encrypted-config.md
+++ b/config/encrypted-config.md
@@ -1,0 +1,195 @@
+# Encrypted Config Management (SOPS & HashiCorp Vault)
+
+RedGuard configs frequently need to reference sensitive material — API tokens for
+C2 frameworks, BloodHound/Neo4j credentials, cloud keys, or target-scoped
+secrets defined in the engagement's Rules of Engagement. **None of these may ever
+be committed in plaintext** (see `CLAUDE.md` → *Safety Rules*).
+
+This guide describes the two supported approaches for keeping secrets out of the
+repository while still feeding them to RedGuard modules at runtime:
+
+| Approach | Best for | Secrets live in |
+| --- | --- | --- |
+| [SOPS](#1-sops-mozilla-sops) | Small teams, GitOps, encrypted files in a repo | Encrypted file (committed) |
+| [HashiCorp Vault](#2-hashicorp-vault) | Shared infra, dynamic/rotating secrets, audit | Central Vault server |
+
+Both integrate through the same contract: a decrypted secret is materialised into
+a process **environment variable** (or an ephemeral file under `secrets/`, which
+is git-ignored) and read by a module via `os.environ`. RedGuard code never reads
+ciphertext directly.
+
+> ⚠️ Every example below uses safe placeholders (`example.com`, `AGE-...EXAMPLE`,
+> `s.EXAMPLETOKEN`). Replace them with real values **only** in your local,
+> untracked environment — never in a commit.
+
+---
+
+## 1. SOPS (Mozilla sops)
+
+[SOPS](https://github.com/getsops/sops) encrypts the *values* of a YAML/JSON file
+while leaving the *keys* readable, so an encrypted config is still diff-friendly
+and reviewable. It supports `age`, GPG, AWS KMS, GCP KMS, Azure Key Vault, and
+HashiCorp Vault as key backends. We standardise on **age** because it needs no
+cloud dependency and is trivial to rotate.
+
+### 1.1 Install
+
+```bash
+# macOS
+brew install sops age
+
+# Debian/Ubuntu
+sudo apt-get install -y age
+# sops: download the binary from the GitHub releases page (getsops/sops)
+```
+
+### 1.2 Generate an age key (one-time, per operator)
+
+```bash
+mkdir -p ~/.config/sops/age
+age-keygen -o ~/.config/sops/age/keys.txt
+# Public key (age1...) is printed — share THIS with the team.
+# The file's AGE-SECRET-KEY-... line is private. NEVER commit it.
+```
+
+Point SOPS at your private key:
+
+```bash
+export SOPS_AGE_KEY_FILE="$HOME/.config/sops/age/keys.txt"
+```
+
+### 1.3 Declare recipients in `.sops.yaml`
+
+Copy [`.sops.yaml.example`](../.sops.yaml.example) to `.sops.yaml` at the repo
+root and replace the placeholder public keys with each operator's `age1...` key.
+SOPS reads this automatically — no need to pass `--age` on every call.
+
+```yaml
+creation_rules:
+  - path_regex: config/secrets\.(enc\.)?ya?ml$
+    age: >-
+      age1exampleoperatoraaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaq,
+      age1exampleoperatorbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbq
+```
+
+### 1.4 Encrypt / decrypt with the helper scripts
+
+A plaintext template lives at
+[`config/secrets.example.yaml`](secrets.example.yaml). Copy it, fill in real
+values locally, then encrypt:
+
+```bash
+cp config/secrets.example.yaml config/secrets.yaml   # git-ignored, plaintext
+$EDITOR config/secrets.yaml                           # add real values
+
+./scripts/sops-encrypt.sh config/secrets.yaml config/secrets.enc.yaml
+git add config/secrets.enc.yaml                        # ciphertext is safe to commit
+rm config/secrets.yaml                                 # never keep plaintext around
+```
+
+Decrypt back to plaintext (e.g. to edit):
+
+```bash
+./scripts/sops-decrypt.sh config/secrets.enc.yaml config/secrets.yaml
+```
+
+To edit ciphertext in place without ever writing plaintext to disk:
+
+```bash
+sops config/secrets.enc.yaml      # opens decrypted in $EDITOR, re-encrypts on save
+```
+
+### 1.5 Feed secrets to RedGuard at runtime
+
+`sops exec-env` decrypts into a child process's environment and nothing touches
+disk:
+
+```bash
+sops exec-env config/secrets.enc.yaml 'redguard run --config configs/config.public.example.json'
+```
+
+Inside a module:
+
+```python
+import os
+
+token = os.environ.get("MYTHIC_API_TOKEN", "")
+if not token:
+    return {"status": "skipped", "detail": "MYTHIC_API_TOKEN not provided"}
+```
+
+### 1.6 Rotating keys
+
+When an operator leaves or a key is compromised:
+
+```bash
+# 1. Remove/replace their age1... key in .sops.yaml
+# 2. Re-encrypt every managed file against the new recipient set:
+sops updatekeys config/secrets.enc.yaml
+```
+
+---
+
+## 2. HashiCorp Vault
+
+[Vault](https://developer.hashicorp.com/vault) is preferred when secrets are
+shared across an engagement team, must be rotated dynamically, or require an
+audit trail. RedGuard reads from Vault's **KV v2** secrets engine.
+
+### 2.1 Authenticate
+
+```bash
+export VAULT_ADDR="https://vault.example.com:8200"
+vault login            # or: export VAULT_TOKEN="s.EXAMPLETOKEN..."
+```
+
+`vault login` supports OIDC, AppRole, and token auth; for CI use AppRole:
+
+```bash
+export VAULT_TOKEN="$(vault write -field=token auth/approle/login \
+    role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")"
+```
+
+### 2.2 Store engagement secrets
+
+```bash
+vault kv put redguard/engagement-acme \
+    MYTHIC_API_TOKEN="REPLACE_ME" \
+    NEO4J_PASSWORD="REPLACE_ME"
+```
+
+### 2.3 Load secrets into the environment
+
+The [`vault-load.sh`](../scripts/vault-load.sh) helper reads a KV v2 path and
+emits `export KEY=value` lines, so you can source it:
+
+```bash
+# Print export statements (review before sourcing):
+./scripts/vault-load.sh redguard/engagement-acme
+
+# Load directly into the current shell:
+source <(./scripts/vault-load.sh redguard/engagement-acme)
+
+redguard run --config configs/config.public.example.json
+```
+
+### 2.4 SOPS + Vault together
+
+SOPS can also use Vault Transit as its key backend (`sops --hc-vault-transit`),
+giving you encrypted-files-in-git *and* centralised key custody. See the SOPS
+docs for `Hc Vault` setup; the file-handling scripts above are unchanged.
+
+---
+
+## 3. Safety checklist
+
+- [ ] `.sops.yaml` contains only **public** `age1...` keys.
+- [ ] No `AGE-SECRET-KEY-...`, `s.<token>`, or PEM private key is ever staged.
+- [ ] Plaintext `config/secrets.yaml` is deleted after encrypting (it is also
+      git-ignored — see the `config/secrets.yaml` entry in `.gitignore` — but
+      delete it anyway so it never lingers).
+- [ ] Ciphertext (`*.enc.yaml`) is reviewed in PRs like any other file.
+- [ ] Vault tokens are short-lived; prefer AppRole over root tokens.
+- [ ] `git status` is clean of any plaintext secret before every commit.
+
+See also: [`docs/playbooks/operational_security.md`](../docs/playbooks/operational_security.md).

--- a/config/secrets.example.yaml
+++ b/config/secrets.example.yaml
@@ -1,0 +1,22 @@
+# Plaintext secrets TEMPLATE for RedGuard.
+#
+# 1. Copy to config/secrets.yaml         (git-ignored)
+# 2. Replace the REPLACE_ME placeholders with real values
+# 3. Encrypt:  ./scripts/sops-encrypt.sh config/secrets.yaml config/secrets.enc.yaml
+# 4. Delete the plaintext copy
+#
+# Keys here mirror the environment variables RedGuard modules read via os.environ.
+# Only the structure is meaningful — every value below is a safe placeholder.
+
+# C2 framework credentials (see modules/c2)
+MYTHIC_API_TOKEN: REPLACE_ME
+SLIVER_OPERATOR_TOKEN: REPLACE_ME
+
+# BloodHound / Neo4j for AD attack-path analysis (see modules/ad_attack)
+NEO4J_URI: bolt://neo4j.example.com:7687
+NEO4J_USER: neo4j
+NEO4J_PASSWORD: REPLACE_ME
+
+# Target-scoped values defined by the engagement Rules of Engagement
+ENGAGEMENT_ID: example-engagement-0000
+TARGET_DOMAIN: example.com

--- a/scripts/sops-decrypt.sh
+++ b/scripts/sops-decrypt.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Decrypt a SOPS-encrypted secrets file (age backend).
+#
+# Usage:   ./scripts/sops-decrypt.sh <ciphertext-in> [plaintext-out]
+# Example: ./scripts/sops-decrypt.sh config/secrets.enc.yaml config/secrets.yaml
+#
+# Requires SOPS_AGE_KEY_FILE to point at your private age key, e.g.
+#   export SOPS_AGE_KEY_FILE="$HOME/.config/sops/age/keys.txt"
+#
+# The decrypted output is plaintext — it is git-ignored and must never be committed.
+set -euo pipefail
+
+IN="${1:-}"
+OUT="${2:-}"
+
+if [[ -z "$IN" ]]; then
+    echo "Usage: $0 <ciphertext-in> [plaintext-out]" >&2
+    exit 64
+fi
+
+if ! command -v sops >/dev/null 2>&1; then
+    echo "ERROR: 'sops' not found. See config/encrypted-config.md for install steps." >&2
+    exit 1
+fi
+
+if [[ ! -f "$IN" ]]; then
+    echo "ERROR: input file '$IN' does not exist." >&2
+    exit 1
+fi
+
+if [[ -z "${SOPS_AGE_KEY_FILE:-}" ]]; then
+    echo "WARNING: SOPS_AGE_KEY_FILE is not set; sops will search default locations." >&2
+fi
+
+if [[ -z "$OUT" ]]; then
+    # Strip a .enc segment if present (foo.enc.yaml -> foo.yaml), else print to stdout.
+    if [[ "$IN" == *.enc.* ]]; then
+        OUT="${IN/.enc./.}"
+    else
+        sops --decrypt "$IN"
+        exit 0
+    fi
+fi
+
+echo "Decrypting '$IN' -> '$OUT' ..."
+sops --decrypt "$IN" > "$OUT"
+echo "Done. '$OUT' is PLAINTEXT — do not commit it; delete it when finished."

--- a/scripts/sops-encrypt.sh
+++ b/scripts/sops-encrypt.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Encrypt a plaintext secrets file with SOPS (age backend).
+#
+# Usage:   ./scripts/sops-encrypt.sh <plaintext-in> [ciphertext-out]
+# Example: ./scripts/sops-encrypt.sh config/secrets.yaml config/secrets.enc.yaml
+#
+# Recipients are taken from .sops.yaml (see config/encrypted-config.md).
+# Never commit the plaintext input — only the encrypted output is safe to commit.
+set -euo pipefail
+
+IN="${1:-}"
+OUT="${2:-}"
+
+if [[ -z "$IN" ]]; then
+    echo "Usage: $0 <plaintext-in> [ciphertext-out]" >&2
+    exit 64
+fi
+
+if ! command -v sops >/dev/null 2>&1; then
+    echo "ERROR: 'sops' not found. See config/encrypted-config.md for install steps." >&2
+    exit 1
+fi
+
+if [[ ! -f "$IN" ]]; then
+    echo "ERROR: input file '$IN' does not exist." >&2
+    exit 1
+fi
+
+if [[ ! -f ".sops.yaml" ]]; then
+    echo "ERROR: .sops.yaml not found. Copy .sops.yaml.example and add your age keys." >&2
+    exit 1
+fi
+
+# Default output: insert .enc before the final extension (foo.yaml -> foo.enc.yaml)
+if [[ -z "$OUT" ]]; then
+    ext="${IN##*.}"
+    base="${IN%.*}"
+    OUT="${base}.enc.${ext}"
+fi
+
+echo "Encrypting '$IN' -> '$OUT' ..."
+sops --encrypt "$IN" > "$OUT"
+echo "Done. Commit '$OUT'; then delete the plaintext '$IN'."

--- a/scripts/vault-load.sh
+++ b/scripts/vault-load.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Read a HashiCorp Vault KV v2 path and emit `export KEY=value` lines for each
+# secret stored there, so RedGuard modules can read them from the environment.
+#
+# Usage:    ./scripts/vault-load.sh <kv-path> [mount]
+# Example:  ./scripts/vault-load.sh redguard/engagement-acme        # mount=secret
+#           source <(./scripts/vault-load.sh redguard/engagement-acme)
+#
+# Requires:
+#   - vault CLI on PATH
+#   - jq on PATH
+#   - VAULT_ADDR set, and a valid token (VAULT_TOKEN or `vault login`)
+#
+# Values are emitted with single-quote escaping; review the output before
+# sourcing it. Nothing is written to disk.
+set -euo pipefail
+
+KV_PATH="${1:-}"
+MOUNT="${2:-secret}"
+
+if [[ -z "$KV_PATH" ]]; then
+    echo "Usage: $0 <kv-path> [mount]" >&2
+    exit 64
+fi
+
+for tool in vault jq; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "ERROR: '$tool' not found. See config/encrypted-config.md." >&2
+        exit 1
+    fi
+done
+
+if [[ -z "${VAULT_ADDR:-}" ]]; then
+    echo "ERROR: VAULT_ADDR is not set (e.g. https://vault.example.com:8200)." >&2
+    exit 1
+fi
+
+# KV v2 stores data under .data.data. Fetch as JSON and turn each key/value into
+# a shell-safe `export KEY='value'` line, escaping any single quote in the value
+# as the standard '\'' sequence so `source <(...)` is safe.
+read -r -d '' JQ_PROG <<'JQ' || true
+.data.data
+| to_entries[]
+| "export \(.key)='" + (.value | tostring | gsub("'"; "'\\''")) + "'"
+JQ
+
+vault kv get -format=json -mount="$MOUNT" "$KV_PATH" | jq -r "$JQ_PROG"


### PR DESCRIPTION
Closes #21.

## What
Adds a guide and helper scripts so engagement secrets stay out of the public repo while still reaching RedGuard modules at runtime.

- `config/encrypted-config.md` — SOPS (age backend) and HashiCorp Vault (KV v2) workflows, plus a safety checklist
- `.sops.yaml.example` — recipient template (public `age1...` keys only)
- `config/secrets.example.yaml` — plaintext template mirroring the env vars modules read
- `scripts/sops-encrypt.sh` / `scripts/sops-decrypt.sh` — file-level encrypt/decrypt with tooling/precondition checks
- `scripts/vault-load.sh` — emits shell-safe `export KEY='value'` lines from a Vault KV v2 path (single-quote escaped; nothing written to disk)
- `.gitignore` — ensures decrypted plaintext (`config/secrets.yaml`, `*.dec.*`, `.sops.yaml`) can never be committed

## Safety
- All examples use placeholders (`example.com`, `age1example...`, `s.EXAMPLETOKEN`). No real secrets, no offensive payloads.
- Scripts validate tool presence and preconditions before acting; no network side effects in this repo.

## Verification
- `bash -n` clean on all three scripts; jq escaping round-trips a value containing a single quote.
- Branch based on `origin/main` so the diff contains only these files.

## Notes
- Orchestrator/CLI wiring intentionally not included — this issue is config tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)